### PR TITLE
Allow symfony/http-foundation ^5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require": {
         "php": "^7.0",
-        "symfony/http-foundation": "^2.7 || ^3.0 || ^4.0"
+        "symfony/http-foundation": "^2.7 || ^3.0 || ^4.0 || ^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5"


### PR DESCRIPTION
This PR allows `symfony/http-foundation` ^5.0 to be used.